### PR TITLE
Fix duplicate errors

### DIFF
--- a/src/hardware/cpu/arm7tdmi/exec/mod.rs
+++ b/src/hardware/cpu/arm7tdmi/exec/mod.rs
@@ -5,7 +5,7 @@
 #![cfg_attr(feature="clippy", warn(wrong_pub_self_convention))]
 #![warn(missing_docs)]
 
-use super::*;
+use super::Arm7Tdmi;
 
 pub use self::armdpop::*;
 pub use self::armbsop::*;


### PR DESCRIPTION
This PR fixes duplicate errors caused by multiple glob imports of the same items.

These duplicate errors were erroneously allowed in some circumstances on the nighties for about a month (see [#32814](https://github.com/rust-lang/rust/pull/32814)), then they triggered ICE (as you reported -- thanks!), and now they are fixed.

We are planning on allowing duplicate glob imports of the same item soon (once we accept [RFC 1560](https://github.com/rust-lang/rfcs/pull/1560)), but they should not have been allowed before then. Sorry for the inconvenience!